### PR TITLE
Mount /tmp as emptyDir for operator

### DIFF
--- a/charts/voyager/templates/deployment-operator.yaml
+++ b/charts/voyager/templates/deployment-operator.yaml
@@ -73,6 +73,8 @@ spec:
         volumeMounts:
         - mountPath: /var/serving-cert
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       {{- if .Values.persistence.enabled }}
         - mountPath: {{ dir .Values.cloudConfig | quote }}
           name: cloudconfig
@@ -92,6 +94,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "voyager.fullname" . }}-apiserver-cert
+      - name: tmp-dir
+        emptyDir: {}
     {{- if .Values.persistence.enabled }}
       - hostPath:
           path: {{ .Values.persistence.hostPath | quote }}


### PR DESCRIPTION
When voyager operator is running with a read-only file system it fails to create ingresses with the following error.

__values.yaml__:
```yaml
securityContext:
  readOnlyRootFilesystem: true
```

__logs__:
```
E0110 20:49:42.410401       1 parser.go:816] loadbalancer "msg"="haproxy.cfg is invalid" "error"="open /tmp/haproxy-config-34592697: read-only file system" "name"="default-ingress" "namespace"="dev-4" 
E0110 20:49:42.410451       1 worker.go:93] Failed to process key dev-4/default-ingress. Reason: open /tmp/haproxy-config-34592697: read-only file system
E0110 20:49:42.410464       1 worker.go:108] open /tmp/haproxy-config-34592697: read-only file system
I0110 20:49:42.410467       1 worker.go:110] Dropping key "dev-4/default-ingress" out of the queue: open /tmp/haproxy-config-34592697: read-only file system
```
