### PR TITLE
Add endpointslices permission to voyager ClusterRole

### DIFF
--- a/charts/voyager/templates/cluster-role.yaml
+++ b/charts/voyager/templates/cluster-role.yaml
@@ -59,6 +59,11 @@ rules:
   - configmaps
   verbs: ["*"]
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
+- apiGroups:
   - ""
   resources:
   - services/finalizers


### PR DESCRIPTION
## Summary
- Add `endpointslices` resource permission under the `discovery.k8s.io` API group to the voyager operator ClusterRole
- Grants `get`, `list`, and `watch` verbs for endpoint slices, enabling the voyager operator to discover service endpoints via the EndpointSlice API