### PR TITLE
Add RBAC for listenersets, horizontalpodautoscalers, and poddisruptionbudgets

### DIFF
--- a/apis/installer/v1alpha1/register.go
+++ b/apis/installer/v1alpha1/register.go
@@ -53,12 +53,14 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&Voyager{},
 		&VoyagerList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/installer/v1alpha1/types_test.go
+++ b/apis/installer/v1alpha1/types_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestDefaultValues(t *testing.T) {
-	checker := schemachecker.New(os.DirFS("../../.."),
+	checker := schemachecker.New(
+		os.DirFS("../../.."),
 		schemachecker.TestCase{Obj: v1alpha1.GatewayConverterSpec{}},
 		schemachecker.TestCase{Obj: v1alpha1.VoyagerGatewaySpec{}},
 		schemachecker.TestCase{Obj: v1alpha1.VoyagerSpec{}},

--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -37,7 +37,7 @@ CMD="./crane"
 
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl-nonroot:1.34 $IMAGE_REGISTRY/appscode/kubectl-nonroot:1.34
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl-nonroot:v1.34 $IMAGE_REGISTRY/appscode/kubectl-nonroot:v1.34
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/crd-manager:v0.2.0 $IMAGE_REGISTRY/voyagermesh/crd-manager:v0.2.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/crd-manager:v0.3.0 $IMAGE_REGISTRY/voyagermesh/crd-manager:v0.3.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/gateway-converter:v0.0.1 $IMAGE_REGISTRY/voyagermesh/gateway-converter:v0.0.1
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/gateway:v1.6.2 $IMAGE_REGISTRY/voyagermesh/gateway:v1.6.2
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/gateway:v1.8.2 $IMAGE_REGISTRY/voyagermesh/gateway:v1.8.2
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/voyager:v17.5.0 $IMAGE_REGISTRY/voyagermesh/voyager:v17.5.0

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -34,9 +34,9 @@ CMD="./images/crane"
 
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl-nonroot:1.34 images/appscode-kubectl-nonroot-1.34.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl-nonroot:v1.34 images/appscode-kubectl-nonroot-v1.34.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/crd-manager:v0.2.0 images/voyagermesh-crd-manager-v0.2.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/crd-manager:v0.3.0 images/voyagermesh-crd-manager-v0.3.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/gateway-converter:v0.0.1 images/voyagermesh-gateway-converter-v0.0.1.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/gateway:v1.6.2 images/voyagermesh-gateway-v1.6.2.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/gateway:v1.8.2 images/voyagermesh-gateway-v1.8.2.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/voyagermesh/voyager:v17.5.0 images/voyagermesh-voyager-v17.5.0.tar
 
 tar -czvf images.tar.gz images

--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -1,6 +1,6 @@
 - ghcr.io/appscode/kubectl-nonroot:1.34
 - ghcr.io/appscode/kubectl-nonroot:v1.34
-- ghcr.io/voyagermesh/crd-manager:v0.2.0
+- ghcr.io/voyagermesh/crd-manager:v0.3.0
 - ghcr.io/voyagermesh/gateway-converter:v0.0.1
-- ghcr.io/voyagermesh/gateway:v1.6.2
+- ghcr.io/voyagermesh/gateway:v1.8.2
 - ghcr.io/voyagermesh/voyager:v17.5.0

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -28,7 +28,7 @@ CMD="./crane"
 
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-kubectl-nonroot-1.34.tar $IMAGE_REGISTRY/appscode/kubectl-nonroot:1.34
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-kubectl-nonroot-v1.34.tar $IMAGE_REGISTRY/appscode/kubectl-nonroot:v1.34
-$CMD push --allow-nondistributable-artifacts --insecure images/voyagermesh-crd-manager-v0.2.0.tar $IMAGE_REGISTRY/voyagermesh/crd-manager:v0.2.0
+$CMD push --allow-nondistributable-artifacts --insecure images/voyagermesh-crd-manager-v0.3.0.tar $IMAGE_REGISTRY/voyagermesh/crd-manager:v0.3.0
 $CMD push --allow-nondistributable-artifacts --insecure images/voyagermesh-gateway-converter-v0.0.1.tar $IMAGE_REGISTRY/voyagermesh/gateway-converter:v0.0.1
-$CMD push --allow-nondistributable-artifacts --insecure images/voyagermesh-gateway-v1.6.2.tar $IMAGE_REGISTRY/voyagermesh/gateway:v1.6.2
+$CMD push --allow-nondistributable-artifacts --insecure images/voyagermesh-gateway-v1.8.2.tar $IMAGE_REGISTRY/voyagermesh/gateway:v1.8.2
 $CMD push --allow-nondistributable-artifacts --insecure images/voyagermesh-voyager-v17.5.0.tar $IMAGE_REGISTRY/voyagermesh/voyager:v17.5.0

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -26,7 +26,7 @@ tar -zxvf $TARBALL
 
 k3s ctr images import images/appscode-kubectl-nonroot-1.34.tar
 k3s ctr images import images/appscode-kubectl-nonroot-v1.34.tar
-k3s ctr images import images/voyagermesh-crd-manager-v0.2.0.tar
+k3s ctr images import images/voyagermesh-crd-manager-v0.3.0.tar
 k3s ctr images import images/voyagermesh-gateway-converter-v0.0.1.tar
-k3s ctr images import images/voyagermesh-gateway-v1.6.2.tar
+k3s ctr images import images/voyagermesh-gateway-v1.8.2.tar
 k3s ctr images import images/voyagermesh-voyager-v17.5.0.tar

--- a/charts/crd-manager/Chart.yaml
+++ b/charts/crd-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: crd-manager
 description: A Helm chart for AppsCode SaaS Calalog
 type: application
-version: v2026.3.6
-appVersion: v0.2.0
+version: v2026.7.21
+appVersion: v0.3.0
 home: https://github.com/appscode-cloud/crd-manager
 icon: https://cdn.appscode.com/images/products/searchlight/icons/android-icon-192x192.png
 sources:

--- a/charts/crd-manager/README.md
+++ b/charts/crd-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/crd-manager --version=v2026.3.6
-$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.3.6
+$ helm search repo appscode/crd-manager --version=v2026.7.21
+$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.7.21
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Voyagermesh CRD Manager operator on a [Kubernetes](http://k
 To install/upgrade the chart with the release name `crd-manager`:
 
 ```bash
-$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.3.6
+$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.7.21
 ```
 
 The command deploys a Voyagermesh CRD Manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -77,12 +77,12 @@ The following table lists the configurable parameters of the `crd-manager` chart
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.3.6 --set registryFQDN=ghcr.io
+$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.7.21 --set registryFQDN=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.3.6 --values values.yaml
+$ helm upgrade -i crd-manager appscode/crd-manager -n gw --create-namespace --version=v2026.7.21 --values values.yaml
 ```

--- a/charts/voyager-gateway/Chart.lock
+++ b/charts/voyager-gateway/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v2024.8.30
 - name: crd-manager
   repository: file://../crd-manager
-  version: v2026.3.6
-digest: sha256:8b9811247c4cd5defa85e424da1b6b581f7db922167fece80d882e131e0e4efc
-generated: "2026-03-11T14:40:37.408266+06:00"
+  version: v2026.7.21
+digest: sha256:383e2e97a837b7634a35e3093c413dbfd973942245b2a009ac934be5e4918ea7
+generated: "2026-07-21T16:04:58.273019182+06:00"

--- a/charts/voyager-gateway/Chart.yaml
+++ b/charts/voyager-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voyager-gateway
 description: The Helm chart for Voyager Gateway
 type: application
-version: v2026.4.30
-appVersion: v1.7.1
+version: v2026.7.21
+appVersion: v1.8.2
 kubeVersion: '>=1.28.0-0'
 annotations:
   charts.openshift.io/name: voyager-gateway
@@ -26,4 +26,4 @@ dependencies:
 - name: crd-manager
   repository: file://../crd-manager
   condition: crd-manager.enabled
-  version: v2026.3.6
+  version: v2026.7.21

--- a/charts/voyager-gateway/templates/_rbac.tpl
+++ b/charts/voyager-gateway/templates/_rbac.tpl
@@ -9,6 +9,8 @@ All namespaced resources for Envoy Gateway RBAC.
 - {{ include "eg.rbac.namespaced.gateway.envoyproxy.status" . | nindent 2 | trim }}
 - {{ include "eg.rbac.namespaced.gateway.networking" . | nindent 2 | trim }}
 - {{ include "eg.rbac.namespaced.gateway.networking.status" . | nindent 2 | trim }}
+- {{ include "eg.rbac.namespaced.autoscaling" . | nindent 2 | trim }}
+- {{ include "eg.rbac.namespaced.policy" . | nindent 2 | trim }}
 - {{ include "eg.rbac.namespaced.gateway.voyagermesh" . | nindent 2 | trim }}
 - {{ include "eg.rbac.namespaced.gateway.voyagermesh.status" . | nindent 2 | trim }}
 {{- if .Values.topologyInjector.enabled }}
@@ -117,6 +119,7 @@ apiGroups:
 - gateway.networking.k8s.io
 resources:
 - gateways
+- listenersets
 - grpcroutes
 - httproutes
 - referencegrants
@@ -135,6 +138,7 @@ apiGroups:
 - gateway.networking.k8s.io
 resources:
 - gateways/status
+- listenersets/status
 - grpcroutes/status
 - httproutes/status
 - tcproutes/status
@@ -251,6 +255,29 @@ verbs:
   - tokenreviews
   verbs:
   - create
+{{- end }}
+
+
+{{- define "eg.rbac.namespaced.autoscaling" -}}
+apiGroups:
+- autoscaling
+resources:
+- horizontalpodautoscalers
+verbs:
+- get
+- list
+- watch
+{{- end }}
+
+{{- define "eg.rbac.namespaced.policy" -}}
+apiGroups:
+- policy
+resources:
+- poddisruptionbudgets
+verbs:
+- get
+- list
+- watch
 {{- end }}
 
 


### PR DESCRIPTION
- Add listenersets and listenersets/status to eg.rbac.namespaced.gateway.networking and .status templates
- Add eg.rbac.namespaced.autoscaling for horizontalpodautoscalers (get, list, watch)
- Add eg.rbac.namespaced.policy for poddisruptionbudgets (get, list, watch)
- Wire both into eg.rbac.namespaced aggregate